### PR TITLE
 Always call on_message_begin for start_req_or_res 

### DIFF
--- a/src/impl/http_parser/lolevel/HTTPParser.java
+++ b/src/impl/http_parser/lolevel/HTTPParser.java
@@ -374,7 +374,6 @@ public class  HTTPParser {
 
           if (H == ch) {
             state = State.res_or_resp_H;
-            settings.call_on_message_begin(this);
           } else {
             type   = ParserType.HTTP_REQUEST;
             method = start_req_method_assign(ch);
@@ -384,6 +383,7 @@ public class  HTTPParser {
             index  = 1;
             state  = State.req_method;
           }
+          settings.call_on_message_begin(this);
           break;
 
 


### PR DESCRIPTION
This fixes basically all of the jruby https://github.com/tmm1/http_parser.rb test failures.
