### PR TITLE
Prevent #on_headers_complete callback from being called 2 times when parsing chunked requests

### DIFF
--- a/src/impl/http_parser/lolevel/HTTPParser.java
+++ b/src/impl/http_parser/lolevel/HTTPParser.java
@@ -374,7 +374,6 @@ public class  HTTPParser {
 
           if (H == ch) {
             state = State.res_or_resp_H;
-            settings.call_on_message_begin(this);
           } else {
             type   = ParserType.HTTP_REQUEST;
             method = start_req_method_assign(ch);
@@ -384,6 +383,7 @@ public class  HTTPParser {
             index  = 1;
             state  = State.req_method;
           }
+          settings.call_on_message_begin(this);
           break;
 
 

--- a/src/impl/http_parser/lolevel/HTTPParser.java
+++ b/src/impl/http_parser/lolevel/HTTPParser.java
@@ -1210,7 +1210,6 @@ return error(settings, "Content-Length not numeric", data);
           if (0 != (flags & F_TRAILING)) {
             /* End of a chunked request */
             state = new_message();
-            settings.call_on_headers_complete(this);
             settings.call_on_message_complete(this);
             break;
           }


### PR DESCRIPTION
Coming back from [here](https://github.com/tmm1/http-parser.java/pull/1) and [here](https://github.com/a2800276/http-parser.java/pull/6).

Currently. the `#on_headers_complete` callback is being fired 2 times when a request with chunked body is parsed. An example that demonstrates the issue can be found [here](https://github.com/tmm1/http_parser.rb/issues/52). 

I've built against my fix locally and tested my ruby script, and it fixes the issue. I didn't add a java test, as the README doesn't tell me how can I setup the environment and run my tests, which is information I'd need before start doing something. 